### PR TITLE
patch: mincost or deductible connection free

### DIFF
--- a/debian/patches/034_mincost_deductible_connectionfee.patch
+++ b/debian/patches/034_mincost_deductible_connectionfee.patch
@@ -1,0 +1,131 @@
+diff --git a/engine/callcost.go b/engine/callcost.go
+index 42def32c4..7056af05d 100644
+--- a/engine/callcost.go
++++ b/engine/callcost.go
+@@ -169,6 +169,50 @@ func (cc *CallCost) UpdateCost() {
+ 	cc.updateCost()
+ }
+ 
++func (cc *CallCost) HasMinCost() bool {
++	if cc.GetConnectFee() == 0 {
++		return false
++	}
++
++	if cc.Timespans[0].RateInterval.Rating.RoundingMethod == utils.ROUNDING_UP_MINCOST {
++		return true
++	}
++
++	return false
++}
++
++func (cc *CallCost) ApplyMinCost() {
++	// ConnectFee is minCost, mangle CostDetails
++	var finalConnectFee, finalCost float64
++
++	initialCost := cc.Cost
++	initialConnectFee := cc.GetConnectFee()
++	minCost := initialConnectFee
++	costWithoutConnectFee := initialCost - initialConnectFee
++
++	if costWithoutConnectFee > minCost {
++		// No ConnectFee necessary
++		finalConnectFee = 0.0
++		finalCost = costWithoutConnectFee
++	} else {
++		// Adjust ConnectFee to reach minCost
++		finalConnectFee = minCost - costWithoutConnectFee
++		finalCost = minCost
++	}
++
++	// Adjust first Timespan Cost value
++	connectFeeReduction := initialConnectFee - finalConnectFee
++	cc.Timespans[0].Cost -= connectFeeReduction
++
++	// Save final ConnectFee
++	cc.Timespans[0].Increments[0].Cost = finalConnectFee
++
++	// Save final Cost
++	cc.Cost = finalCost
++
++	return
++}
++
+ func (cc *CallCost) updateCost() {
+ 	cost := 0.0
+ 	//if cc.deductConnectFee { // add back the connectFee
+diff --git a/engine/cdrs.go b/engine/cdrs.go
+index 8dd28811e..d622c5f83 100644
+--- a/engine/cdrs.go
++++ b/engine/cdrs.go
+@@ -284,6 +284,15 @@ func (self *CdrServer) deriveRateStoreStatsReplicate(cdr *CDR, store, cdrstats,
+ 		for _, ratedCDR := range ratedCDRs {
+ 			if ratedCDR.CostDetails != nil {
+ 				ratedCDR.CostDetails.UpdateCost()
++				if ratedCDR.CostDetails.HasMinCost() {
++					ratedCDR.CostDetails.ApplyMinCost()
++					newCost := ratedCDR.CostDetails.Cost
++					refundBalance := ratedCDR.Cost - newCost
++					if err := self.refundCharges(ratedCDR.Tenant, ratedCDR.Account, refundBalance) ; err != nil {
++						fmt.Println(err)
++					}
++					ratedCDR.Cost = newCost
++				}
+ 				ratedCDR.CostDetails.UpdateRatedUsage()
+ 			}
+ 			if err := self.cdrDb.SetCDR(ratedCDR, true); err != nil {
+@@ -520,10 +529,8 @@ func (self *CdrServer) replicateCDRs(cdrs []*CDR) (err error) {
+ 	return
+ }
+ 
+-func (self *CdrServer) refundCharges(cdr *CDR) error {
+-	utils.Logger.Info(fmt.Sprintf("Refund %f to '%s:%s' [cgrid: %s]\n", cdr.Cost, cdr.Tenant, cdr.Account, cdr.CGRID))
+-
+-	accID := utils.AccountKey(cdr.Tenant, cdr.Account)
++func (self *CdrServer) refundCharges(tenant string, account string, amount float64) error {
++	accID := utils.AccountKey(tenant, account)
+ 	at := &ActionTiming{}
+ 	at.SetAccountIDs(utils.StringMap{accID: true})
+ 
+@@ -532,7 +539,7 @@ func (self *CdrServer) refundCharges(cdr *CDR) error {
+ 		Balance: &BalanceFilter{
+ 			ID:	 		utils.StringPointer("*default"),
+ 			Type:		utils.StringPointer("*monetary"),
+-			Value:      &utils.ValueFormula{Static: cdr.Cost},
++			Value:      &utils.ValueFormula{Static: amount},
+ 		},
+ 	}
+ 	at.SetActions(Actions{a})
+@@ -555,7 +562,7 @@ func (self *CdrServer) RateCDRs(cdrFltr *utils.CDRsFilter, sendToStats bool, ref
+ 			continue
+ 		}
+ 		if refund && cdr.Cost > 0 {
+-			if err := self.refundCharges(cdr) ; err != nil {
++			if err := self.refundCharges(cdr.Tenant, cdr.Account, cdr.Cost) ; err != nil {
+ 				return err
+ 			}
+ 		}
+diff --git a/utils/consts.go b/utils/consts.go
+index ab25711b3..825d6f575 100755
+--- a/utils/consts.go
++++ b/utils/consts.go
+@@ -107,6 +107,7 @@ const (
+ 	META_NONE                     = "*none"
+ 	META_NOW                      = "*now"
+ 	ROUNDING_UP                   = "*up"
++	ROUNDING_UP_MINCOST           = "*upmincost"
+ 	ROUNDING_MIDDLE               = "*middle"
+ 	ROUNDING_DOWN                 = "*down"
+ 	ANY                           = "*any"
+diff --git a/utils/coreutils.go b/utils/coreutils.go
+index dd012fbfc..564ad7ac9 100644
+--- a/utils/coreutils.go
++++ b/utils/coreutils.go
+@@ -131,7 +131,7 @@ func Round(x float64, prec int, method string) float64 {
+ 	_, frac := math.Modf(intermed)
+ 
+ 	switch method {
+-	case ROUNDING_UP:
++	case ROUNDING_UP, ROUNDING_UP_MINCOST:
+ 		if frac >= math.Pow10(-maxPrec) { // Max precision we go, rest is float chaos
+ 			rounder = math.Ceil(intermed)
+ 		} else {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -30,3 +30,4 @@
 031_reverse_destination_redesign.patch
 032_set_account_override_logic.patch
 033_remove_sm_cost_after_reading.patch
+034_mincost_deductible_connectionfee.patch


### PR DESCRIPTION
This PR makes the following changes:

- On CDR generation logic (on call hangup), CDR costDetails are evaluated.

- If roundingMethod of destinationRate equals *upmincost (new roundingMethod, identical to *up but with this tweak) and ConnectionFee is greater than 0, minCost logic applies. If not, no changes are made.

- In MinCost logic, ConnectionFee treated as MinCost:

  - If cost without connection fee is greater than ConnectionFee, ConnectionFee is deducted (ConnectionFee will be set to 0 and cost will be reduced).

  - If cost without connection fee is less than ConnectionFee, cost is updated to ConnectionFee (to MinCost) and ConnectionFee value is adapted.

- In both cases, account balances (both company and carrier if needed) will be refunded with calculated price difference.