### PR TITLE
patch: add account to endCompanyCalls URL as param

### DIFF
--- a/debian/patches/035_endcompanycalls_urlparam.patch
+++ b/debian/patches/035_endcompanycalls_urlparam.patch
@@ -1,0 +1,15 @@
+diff --git a/engine/action.go b/engine/action.go
+index b554184fa..7cacd8ac6 100644
+--- a/engine/action.go
++++ b/engine/action.go
+@@ -419,6 +419,10 @@ func callUrl(ub *Account, sq *CDRStatsQueueTriggered, a *Action, acs Actions) er
+ 	ffn := &utils.FallbackFileName{Module: fmt.Sprintf("%s>%s", utils.ActionsPoster, a.ActionType),
+ 		Transport: utils.MetaHTTPjson, Address: a.ExtraParameters,
+ 		RequestID: utils.GenUUID(), FileSuffix: utils.JSNSuffix}
++    if strings.Contains(a.ExtraParameters, "endCompanyCalls") {
++        a.ExtraParameters += fmt.Sprintf("?account=%s", ub.ID) // Append account as URL param
++        fmt.Printf("End company calls calling URL %q\n", a.ExtraParameters)
++    }
+ 	_, err = utils.NewHTTPPoster(config.CgrConfig().HttpSkipTlsVerify,
+ 		config.CgrConfig().ReplyTimeout).Post(a.ExtraParameters, utils.CONTENT_JSON, jsn,
+ 		config.CgrConfig().PosterAttempts, path.Join(cfg.FailedPostsDir, ffn.AsString()))

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,3 +31,4 @@
 032_set_account_override_logic.patch
 033_remove_sm_cost_after_reading.patch
 034_mincost_deductible_connectionfee.patch
+035_endcompanycalls_urlparam.patch


### PR DESCRIPTION
Add disabled account to URL param:

http://trunks.ivozprovider.local:8001/endCompanyCalls -> http://trunks.ivozprovider.local:8001/endCompanyCalls?account=b1:c3